### PR TITLE
fix reference count when client with multiple connections is terminated

### DIFF
--- a/geoclue/geoclue/gc-provider.c
+++ b/geoclue/geoclue/gc-provider.c
@@ -171,8 +171,8 @@ set_options (GcIfaceGeoclue *geoclue,
 		return klass->set_options (geoclue, options, error);
 	} 
 
-        /* It is not an error to not have a SetOptions implementation */
-        return TRUE;
+	/* It is not an error to not have a SetOptions implementation */
+	return TRUE;
 }
 
 static gboolean 
@@ -189,7 +189,7 @@ gc_provider_remove_reference (GcProvider *provider, const char *client)
 	(*pcount)--;
 	if (*pcount == 0) {
 		g_hash_table_remove (priv->connections, client);
-        }
+	}
 	if (g_hash_table_size (priv->connections) == 0) {
 		gc_provider_shutdown (provider);
 	}
@@ -207,7 +207,7 @@ gc_provider_remove_client (GcProvider *provider, const char *client)
 		return FALSE;
 	}
 	
-        g_hash_table_remove (priv->connections, client);
+	g_hash_table_remove (priv->connections, client);
 	if (g_hash_table_size (priv->connections) == 0) {
 		gc_provider_shutdown (provider);
 	}
@@ -216,7 +216,7 @@ gc_provider_remove_client (GcProvider *provider, const char *client)
 
 static void
 add_reference (GcIfaceGeoclue *geoclue,
-               DBusGMethodInvocation *context)
+	       DBusGMethodInvocation *context)
 {
 	GcProviderPrivate *priv = GET_PRIVATE (geoclue);
 	char *sender;
@@ -236,7 +236,7 @@ add_reference (GcIfaceGeoclue *geoclue,
 
 static void 
 remove_reference (GcIfaceGeoclue *geoclue,
-                  DBusGMethodInvocation *context)
+		  DBusGMethodInvocation *context)
 {
 	GcProvider *provider = GC_PROVIDER (geoclue);
 	char *sender;

--- a/geoclue/geoclue/gc-provider.c
+++ b/geoclue/geoclue/gc-provider.c
@@ -196,18 +196,14 @@ gc_provider_remove_reference (GcProvider *provider, const char *client)
 	return TRUE;
 }
 
-static gboolean 
+static gboolean
 gc_provider_remove_client (GcProvider *provider, const char *client)
 {
-	int *pcount;
 	GcProviderPrivate *priv = GET_PRIVATE (provider);
-	
-	pcount = g_hash_table_lookup (priv->connections, client);
-	if (!pcount) {
+
+	if (!g_hash_table_remove (priv->connections, client)) {
 		return FALSE;
 	}
-	
-	g_hash_table_remove (priv->connections, client);
 	if (g_hash_table_size (priv->connections) == 0) {
 		gc_provider_shutdown (provider);
 	}

--- a/rpm/geoclue.spec
+++ b/rpm/geoclue.spec
@@ -164,7 +164,7 @@ Summary: provider for %{name}
 
 %build
 autoreconf -vfi
-%configure --enable-static=no --enable-connman=no
+%configure --enable-static=no --enable-connman=no --enable-gpsd=no
 make %{?_smp_mflags}
 
 


### PR DESCRIPTION
libgeoclue maintains a hashtable with names of clients and their connection count. When a client is terminated, dbus triggers `name_owner_changed` in `gc-provider.c` which should remove all references for this client but removes only one.

This patch fixes that bug and makes [geoclue-provider-gpsd3](https://github.com/neochapay/geoclue-provider-gpsd3) behave poperly.